### PR TITLE
Fixed notes editor color in dark mode.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -158,8 +158,13 @@
   background: #272727 !important;
 }
 
-.dark .ant-select-selection-item-remove, .dark .ant-progress-circle .ant-progress-text, .dark .ant-radio-wrapper, .dark .ant-tabs {
+.dark .ant-select-selection-item-remove, .dark .ant-progress-circle .ant-progress-text, .dark .ant-radio-wrapper, .dark .ant-tabs, .dark .editor-toolbar button {
   color: #fff !important;
+}
+
+.dark .editor-toolbar button:hover,
+.dark .editor-toolbar button.active {
+  background: #272727 !important;
 }
 
 .dark .react-kanban-column, .dark .news-feed {


### PR DESCRIPTION
The color of the notes editor in dark mode is changed to white.
Buttons hover, active state color is matched with dark mode.

closes #18. 